### PR TITLE
Update commodity series start date and extend data to now

### DIFF
--- a/download_raw_data.py
+++ b/download_raw_data.py
@@ -3,7 +3,7 @@ import yfinance as yf
 import pandas as pd
 
 START_DATE = "2015-01-01"
-END_DATE = "2025-01-01"
+END_DATE = "2026-01-01"
 INTERVAL = "1d"
 
 BASE_DATA_DIR = "data"
@@ -21,7 +21,7 @@ ASSET_GROUPS = {
         "SGLD.L",      
     ],
     "commodities": [
-        "WCOG.L",      
+        "AIGC.L",      
     ],
 }
 


### PR DESCRIPTION
This PR updates the portfolio optimisation input data to use a corrected commodity time series that starts on 01/01/2015 instead of April 2016, ensuring a consistent and longer backtest window. It also aligns all instruments’ data end dates to now, so the optimisation, performance metrics, and any downstream analytics run over a uniform sample period. Please review the updated dataset, verify that the optimisation scripts run as expected, and confirm that no assumptions elsewhere rely on the old date range.